### PR TITLE
switching to qgraphicsitem and qgraphicslineitem classes and correction of line's bounding rect

### DIFF
--- a/gui/cadcommandadd.h
+++ b/gui/cadcommandadd.h
@@ -3,7 +3,7 @@
 
 #include <QUndoCommand>
 #include <QGraphicsScene>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
 #include "point.h"
 #include "line.h"
@@ -14,62 +14,62 @@
 class CadCommandAdd : public QUndoCommand
 {
 public:
-    CadCommandAdd(QGraphicsScene *scene, QGraphicsItemGroup *group)
+    CadCommandAdd(QGraphicsScene *scene, QGraphicsItem *item)
     {
-        itemGroup = group;
+        m_item = item;
         m_scene = scene;
 
-        if (itemGroup->type() == Point::Type)
+        if (m_item->type() == Point::Type)
         {
             setText(QString("Point add p(%1,%2)")
-                    .arg(itemGroup->scenePos().x())
-                    .arg(itemGroup->scenePos().y()));
+                    .arg(m_item->scenePos().x())
+                    .arg(m_item->scenePos().y()));
         }
-        if (itemGroup->type() == Line::Type)
+        if (m_item->type() == Line::Type)
         {
-            Line *lineGroup = dynamic_cast<Line *>(itemGroup);
+            Line *lineItem = dynamic_cast<Line *>(m_item);
             setText(QString("Line add p1(%1,%2), p2(%3,%4)")
-                    .arg(lineGroup->start_p.x()).arg(lineGroup->start_p.y())
-                    .arg(lineGroup->end_p.x()).arg(lineGroup->end_p.y()));
+                    .arg(lineItem->start_p.x()).arg(lineItem->start_p.y())
+                    .arg(lineItem->end_p.x()).arg(lineItem->end_p.y()));
         }
-        if (itemGroup->type() == Circle::Type)
+        if (m_item->type() == Circle::Type)
         {
-            Circle *circleGroup = dynamic_cast<Circle *>(itemGroup);
+            Circle *circleItem = dynamic_cast<Circle *>(m_item);
             setText(QString("Circle add c(%1,%2), r(%3)")
-                    .arg(circleGroup->center_p.x())
-                    .arg(circleGroup->center_p.y())
-                    .arg(circleGroup->radius));
+                    .arg(circleItem->center_p.x())
+                    .arg(circleItem->center_p.y())
+                    .arg(circleItem->radius));
         }
-        if (itemGroup->type() == Ellipse::Type)
+        if (m_item->type() == Ellipse::Type)
         {
-            Ellipse *ellipseGroup = dynamic_cast<Ellipse *>(itemGroup);
+            Ellipse *ellipseItem = dynamic_cast<Ellipse *>(m_item);
             setText(QString("Ellipse add c(%1,%2), mjR(%3), mnR(%4)")
-                    .arg(ellipseGroup->p1.x())
-                    .arg(ellipseGroup->p1.y())
-                    .arg(ellipseGroup->majRadius)
-                    .arg(ellipseGroup->minRadius));
+                    .arg(ellipseItem->p1.x())
+                    .arg(ellipseItem->p1.y())
+                    .arg(ellipseItem->majRadius)
+                    .arg(ellipseItem->minRadius));
         }
     }
 
     ~CadCommandAdd()
     {
-        // if itemGroup is not on scene then delete that itemGroup
-        if (!m_scene->items().contains(itemGroup))
-            delete itemGroup;
+        // if m_item is not on scene then delete that m_item
+        if (!m_scene->items().contains(m_item))
+            delete m_item;
     }
 
     virtual void undo()
     {
-        m_scene->removeItem(itemGroup);
+        m_scene->removeItem(m_item);
     }
 
     virtual void redo()
     {
-        m_scene->addItem(itemGroup);
+        m_scene->addItem(m_item);
     }
 
 private:
-    QGraphicsItemGroup *itemGroup;
+    QGraphicsItem *m_item;
     QGraphicsScene *m_scene;
 };
 

--- a/gui/cadcommanddelete.h
+++ b/gui/cadcommanddelete.h
@@ -3,7 +3,7 @@
 
 #include <QUndoCommand>
 #include <QGraphicsScene>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
 #include "point.h"
 #include "line.h"
@@ -14,54 +14,54 @@
 class CadCommandDelete : public QUndoCommand
 {
 public:
-    CadCommandDelete(QGraphicsScene *scene, QGraphicsItemGroup *group)
+    CadCommandDelete(QGraphicsScene *scene, QGraphicsItem *item)
     {
         m_scene = scene;
-        itemGroup = group;
-        if (itemGroup->type() == Point::Type)
+        m_item = item;
+        if (m_item->type() == Point::Type)
         {
             setText(QString("Point delete p(%1,%2)")
-                    .arg(itemGroup->scenePos().x())
-                    .arg(itemGroup->scenePos().y()));
+                    .arg(m_item->scenePos().x())
+                    .arg(m_item->scenePos().y()));
         }
-        if (itemGroup->type() == Line::Type)
+        if (m_item->type() == Line::Type)
         {
-            Line *lineGroup = dynamic_cast<Line *>(itemGroup);
+            Line *lineItem = dynamic_cast<Line *>(m_item);
             setText(QString("Line delete p1(%1,%2), p2(%3,%4)")
-                    .arg(lineGroup->start_p.x()).arg(lineGroup->start_p.y())
-                    .arg(lineGroup->end_p.x()).arg(lineGroup->end_p.x()));
+                    .arg(lineItem->start_p.x()).arg(lineItem->start_p.y())
+                    .arg(lineItem->end_p.x()).arg(lineItem->end_p.x()));
         }
-        if (itemGroup->type() == Circle::Type)
+        if (m_item->type() == Circle::Type)
         {
-            Circle *circleGroup = dynamic_cast<Circle *>(itemGroup);
+            Circle *circleItem = dynamic_cast<Circle *>(m_item);
             setText(QString("Circle delete c(%1,%2), r(%3)")
-                    .arg(circleGroup->center_p.x())
-                    .arg(circleGroup->center_p.y())
-                    .arg(circleGroup->radius));
+                    .arg(circleItem->center_p.x())
+                    .arg(circleItem->center_p.y())
+                    .arg(circleItem->radius));
         }
-        if (itemGroup->type() == Ellipse::Type)
+        if (m_item->type() == Ellipse::Type)
         {
-            Ellipse *ellipseGroup = dynamic_cast<Ellipse *>(itemGroup);
+            Ellipse *ellipseItem = dynamic_cast<Ellipse *>(m_item);
             setText(QString("Ellipse delete c(%1,%2), mjR(%3), mnR(%4)")
-                    .arg(ellipseGroup->p1.x())
-                    .arg(ellipseGroup->p1.y())
-                    .arg(ellipseGroup->majRadius)
-                    .arg(ellipseGroup->minRadius));
+                    .arg(ellipseItem->p1.x())
+                    .arg(ellipseItem->p1.y())
+                    .arg(ellipseItem->majRadius)
+                    .arg(ellipseItem->minRadius));
         }
     }
 
     virtual void undo()
     {
-        m_scene->addItem(itemGroup);
+        m_scene->addItem(m_item);
     }
 
     virtual void redo()
     {
-        m_scene->removeItem(itemGroup);
+        m_scene->removeItem(m_item);
     }
 
 private:
-    QGraphicsItemGroup *itemGroup;
+    QGraphicsItem *m_item;
     QGraphicsScene *m_scene;
 };
 

--- a/gui/cadcommandmove.h
+++ b/gui/cadcommandmove.h
@@ -3,7 +3,7 @@
 
 #include <QUndoCommand>
 #include <QGraphicsScene>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
 #include "point.h"
 #include "line.h"
@@ -14,10 +14,10 @@
 class CadCommandMove : public QUndoCommand
 {
 public:
-    CadCommandMove(QGraphicsItemGroup *group, qreal fromX, qreal fromY,
+    CadCommandMove(QGraphicsItem *item, qreal fromX, qreal fromY,
                    qreal toX, qreal toY)
     {
-        itemGroup = group;
+        m_item = item;
         mFrom = QPointF(fromX, fromY);
         mTo = QPointF(toX, toY);
         setText(QString("Point move (%1,%2) -> (%3,%4)").arg(fromX).arg(fromY)
@@ -26,16 +26,16 @@ public:
 
     virtual void undo()
     {
-        itemGroup->setPos(mFrom);
+        m_item->setPos(mFrom);
     }
 
     virtual void redo()
     {
-        itemGroup->setPos(mTo);
+        m_item->setPos(mTo);
     }
 
 private:
-    QGraphicsItemGroup *itemGroup;
+    QGraphicsItem *m_item;
     QPointF mFrom;
     QPointF mTo;
 };

--- a/gui/cadgraphicsscene.h
+++ b/gui/cadgraphicsscene.h
@@ -34,7 +34,7 @@ public:
 
 public slots:
     void setMode(Mode mode);
-    void selectGroups();
+    void selectItems();
     void editorLostFocus(mText *item);
 
 protected:
@@ -59,7 +59,7 @@ private:
     QPointF start_p, mid_p, end_p, move_p, check_p;
     QPen paintpen, linePen;
 
-    QList<QGraphicsItemGroup *> groupList;
+    QList<QGraphicsItem *> itemList;
     Point *pointItem;
     Line *lineItem;
     Circle *circleItem;
@@ -68,8 +68,8 @@ private:
     QColor myTextColor;
     QFont myFont;
 
-    typedef QPair<QGraphicsItemGroup *, QPointF> itemPos;
-    QList<itemPos> selectedGroups;
+    typedef QPair<QGraphicsItem *, QPointF> itemPos;
+    QList<itemPos> selectedItems;
 };
 
 #endif // CADGRAPHICSSCENE_H

--- a/gui/entities/circle.h
+++ b/gui/entities/circle.h
@@ -2,11 +2,11 @@
 #define CIRCLE_H
 
 #include <QPainter>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
 #include "qmath.h"
 
-class Circle : public QObject, public QGraphicsItemGroup
+class Circle : public QObject, public QGraphicsItem
 {
     Q_OBJECT
 public:

--- a/gui/entities/ellipse.h
+++ b/gui/entities/ellipse.h
@@ -2,11 +2,11 @@
 #define ELLIPSE_H
 
 #include <QPainter>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
 #include "qmath.h"
 
-class Ellipse : public QObject, public QGraphicsItemGroup
+class Ellipse : public QObject, public QGraphicsItem
 {
     Q_OBJECT
 public:

--- a/gui/entities/line.cpp
+++ b/gui/entities/line.cpp
@@ -18,8 +18,13 @@ int Line::type() const
 
 QRectF Line::boundingRect() const
 {
+    qreal extra = 1.0;
+
     // bounding rectangle for line
-    return QRectF(start_p, end_p).normalized();
+    return QRectF(line().p1(), QSizeF(line().p2().x() - line().p1().x(),
+                                      line().p2().y() - line().p1().y()))
+            .normalized()
+            .adjusted(-extra, -extra, extra, extra);
 }
 
 void Line::paint(QPainter *painter, const QStyleOptionGraphicsItem *option,

--- a/gui/entities/line.h
+++ b/gui/entities/line.h
@@ -2,9 +2,9 @@
 #define LINE_H
 
 #include <QPainter>
-#include <QGraphicsItemGroup>
+#include <QGraphicsLineItem>
 
-class Line : public QObject, public QGraphicsItemGroup
+class Line : public QObject, public QGraphicsLineItem
 {
     Q_OBJECT
 public:

--- a/gui/entities/point.h
+++ b/gui/entities/point.h
@@ -2,9 +2,9 @@
 #define POINT_H
 
 #include <QPainter>
-#include <QGraphicsItemGroup>
+#include <QGraphicsItem>
 
-class Point : public QObject, public QGraphicsItemGroup
+class Point : public QObject, public QGraphicsItem
 {
     Q_OBJECT
 public:


### PR DESCRIPTION
The use of making groups is not needed. Appending an item as a whole to the list makes things work similarly. Also this commit solves fifty percent of the issue #49 by correcting bounding rectangle for line.
