### PR TITLE
removes the destructor in cadaddcommand

### DIFF
--- a/gui/cadcommandadd.h
+++ b/gui/cadcommandadd.h
@@ -56,13 +56,6 @@ public:
         }
     }
 
-    ~CadCommandAdd()
-    {
-        // if m_item is not on scene then delete that m_item
-        if (!m_scene->items().contains(m_item))
-            delete m_item;
-    }
-
     virtual void undo()
     {
         m_scene->removeItem(m_item);


### PR DESCRIPTION
This resolves the crashing that occurred whenever undo was repeatedly done and the state at the stack's top was reached. So issue #51 is solved.
