### PR TITLE
corrects the size of entities in print preview and print

### DIFF
--- a/gui/mainwindow.cpp
+++ b/gui/mainwindow.cpp
@@ -112,6 +112,7 @@ void MainWindow::toggleActions(bool b)
     actionCopy->setEnabled(b);
     actionPaste->setEnabled(b);
     actionToolbar->setEnabled(b);
+    actionClose->setEnabled(b);
 }
 
 void MainWindow::setActions()
@@ -411,6 +412,8 @@ void MainWindow::print(QPrinter *printer)
 
     //hides/disables grid for print and print preview
     view->scene->isGridVisible = false;
+    view->scene->setSceneRect(view->scene->itemsBoundingRect()
+                              .adjusted(-10,-10,10,10));
     view->scene->render(&painter, page);
     view->scene->isGridVisible = true;
 }


### PR DESCRIPTION
This solves #57 and disables Close when no document is present in MDI area.
