### PR TITLE
corrects mouse axes on zoom in

### DIFF
--- a/gui/cadgraphicsscene.cpp
+++ b/gui/cadgraphicsscene.cpp
@@ -48,16 +48,6 @@ bool CadGraphicsScene::eventFilter(QObject *watched, QEvent *event)
                                 QPointF(mouseEvent->scenePos().x(),
                                         sceneRect().bottomLeft().y()));
 
-        // sets graphicscoloreffect for axis
-        effect1 = new QGraphicsColorizeEffect;
-        effect2 = new QGraphicsColorizeEffect;
-        effect1->setColor(Qt::red);
-        effect2->setColor(Qt::red);
-        effect1->setStrength(0.5);
-        effect2->setStrength(0.5);
-        horizontalAxis->setGraphicsEffect(effect1);
-        verticalAxis->setGraphicsEffect(effect2);
-
         if (!previewList.isEmpty())
         {
             foreach (QGraphicsItem *item, previewList)

--- a/gui/cadgraphicsscene.h
+++ b/gui/cadgraphicsscene.h
@@ -6,7 +6,6 @@
 #include <QUndoStack>
 #include <QMenu>
 #include <QToolTip>
-#include <QGraphicsColorizeEffect>
 
 #include "qmath.h"
 #include "cadcommands/cadcommandadd.h"
@@ -78,7 +77,6 @@ private:
 
     QList<QGraphicsItem *> itemList;
     QList<QGraphicsItem *> previewList;
-    QGraphicsColorizeEffect *effect1, *effect2;
     Point *pointItem;
     Line *lineItem;
     Line *horizontalAxis, *verticalAxis;


### PR DESCRIPTION
Solves #206 

Note: The color of the axes must be set (if needed) by some other method. QGraphicsColorizeEffect class decreases the performance significantly.
